### PR TITLE
Fixed a typo for MacOS

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -121,7 +121,7 @@ After finish installing, type:
 brew install allegro
 ```
 
-Open `XCode`, Create a new `MacOS` project, choose `Cocoa App`.
+Open `XCode`, Create a new `MacOS` project, choose `App`.
 
 Product Name type `allegro-test`, and for Organization Identifier, you can type anything you want. For language, choose `Objective-C`, and uncheck all other checkboxes.
 


### PR DESCRIPTION
Hello,
Xcode has been updated.
The news version replace "Cocoa App" with "App".

![](https://i.imgur.com/BOQ8cps.png)

